### PR TITLE
Properly Populating HTML Table On Initial Calc

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,11 +78,11 @@
                 <thead>
                     <tr>
                         <th>Month</th>
-                        <th>Year / Month</th>
+                        <!--<th>Year / Month</th>-->
                         <th>Total Payment</th>
                         <th>Principal</th>
                         <th>Interest</th>
-                        <th>Insurance</th>
+                        <!--<th>Insurance</th>-->
                         <th>Outstanding Principal</th>
                         <th>Interest Running Total</th>
                     </tr>

--- a/js/index.js
+++ b/js/index.js
@@ -13,6 +13,10 @@ const tablePaymentDetails = document.getElementById('tablePaymentDetails');
 
 let myMortgage = new Mortgage(principalAmountField.value, intertestRateField.value, radioTerm30.checked ? 30 : 15);
 
+function formatDollarsAndCents(myNumber) {
+    return myNumber.toLocaleString('en-US', {style: 'currency', currency: 'USD'});
+}
+
 document.addEventListener('DOMContentLoaded', function(){
     //set defaults
     //look to replace this - probably shouldn't have hardcoded values in the script.
@@ -59,20 +63,25 @@ function calculateMortgage() {
     //console.log(myMortgage.getPrincipalAndInterestSplit());
     //console.log(myMortgage.calculateMortageDetail());
     //console.log(tablePaymentDetails);
-    tablePaymentDetails.innerHTML += calculateMortgageDetail();
+    tablePaymentDetails.innerHTML += populateMortgageDetail();
 }
 
-function calculateMortgageDetail() {
+function populateMortgageDetail() {
     //summaryTotalPayment.innerText = `\$${myMortgage.getPrincipalAndInterest()}`;
     //summaryTotalInterest.innerText = `${myMortgage.formatDollarsAndCents(myMortgage.getTotalInterest())}`;
     let htmlInnerText = '<tbody>';
-    for (month in myMortgage.calculateMortgageDetail()) {
+    let amortSchedJSON = myMortgage.calculateMortgageDetail();
+    for (let payment in amortSchedJSON) {
         //work to add these to final list of rows of html to be returned.
+        console.log(payment);
 
         htmlInnerText += `<tr>
-            <td>${month['principalInterest']}</td>
-            <td>${month['principal']}</td>
-            <td>${month['interest']}</td>
+            <td>${amortSchedJSON[payment].paymentNumber}</td>
+            <td>${formatDollarsAndCents(amortSchedJSON[payment].principalInterest)}</td>
+            <td>${formatDollarsAndCents(amortSchedJSON[payment].principal)}</td>
+            <td>${formatDollarsAndCents(amortSchedJSON[payment].interest)}</td>
+            <td>${formatDollarsAndCents(amortSchedJSON[payment].principalOutstanding)}</td>
+            <td>${formatDollarsAndCents(amortSchedJSON[payment].interestRunningTotal)}</td>
         </tr>`;
 
         //htmlInnerText += `<tr>

--- a/js/mortgage.js
+++ b/js/mortgage.js
@@ -51,7 +51,12 @@ class Mortgage {
             interestRunningTotal += curInterest;
             outstandingPrincipal = this.toFixedNumber(outstandingPrincipal - curPrincipal, 2);
 
-            amortArray.push({'principalInterest': curPrincipalInterest, 'principal': curPrincipal, 'interest': curInterest})
+            amortArray.push({'paymentNumber': monthNumber
+                , 'principalInterest': curPrincipalInterest
+                , 'principal': curPrincipal
+                , 'interest': curInterest
+                , 'principalOutstanding': this.toFixedNumber(outstandingPrincipal, 2) 
+                , 'interestRunningTotal': this.toFixedNumber(interestRunningTotal, 2)});
 
             //Protection Against Infinite Loop
             if (monthNumber > 5000) {


### PR DESCRIPTION
Fixing the population of the HTML table, along with adding additional data points to be provided to the HTML table (e.g. Interest Running Total). Discovered the need to modify how the HTML table is being populated, as the second+ click of the Calc Mortgage button will append the correct relevant data, without clearing out the previous calculations - not what a user would be expecting. Also need to add the ability to get the summary populating again.