### PR TITLE
Making HTML Table Header Stay Visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -62,6 +62,20 @@ h2 {
     grid-template-columns: repeat(3, 1fr);
 }
 
+#details {
+    overflow: auto;
+    height: 500px;
+}
+
+#details thead tr th {
+    background-color: rgba(100, 100, 100, 1);
+}
+
+#details thead th {
+    position:sticky;
+    top:0;
+}
+
 #details table, th, td {
     border: 1px solid black;
     border-collapse: collapse;
@@ -71,6 +85,10 @@ h2 {
     text-align: center;
     font-family: 'Courier New', Courier, monospace;
     font-weight: bold;
+}
+
+#details thead {
+    position: sticky;
 }
 
 #details table tbody tr:nth-child(even) {


### PR DESCRIPTION
Modifying the CSS to change how the HTML table behaves, making the header row stay visible regardless of where the user scrolls to. It's not a perfect solution, but much better than not having the headers in sight at all.