### PR TITLE
Adding Additional Principal to Table Results

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -71,7 +71,7 @@ thead tr {
     border: 1px solid black !important;
 }
 
-thead th {
+thead tr {
     top: 0;
     border: 1px solid black !important;
     z-index: 99;    

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
                         <th>Total Payment</th>
                         <th>Principal</th>
                         <th>Interest</th>
+                        <th>Additional Principal</th>
                         <!--<th>Insurance</th>-->
                         <th>Outstanding Principal</th>
                         <th>Interest Running Total</th>

--- a/js/index.js
+++ b/js/index.js
@@ -175,6 +175,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
     myMortgage.principalDollars = parseFloat(principalAmountField.value);
     myMortgage.interestRate = parseFloat(intertestRateField.value);
+    myMortgage.additionalPrincipal = parseFloat(additionalPrincipalField.value);
 
     //default to 30 year term
     //force the change to trigger the listener
@@ -197,7 +198,12 @@ document.addEventListener('DOMContentLoaded', function(){
 //intertestRateField.addEventListener('change', changeInterestRate)
 radioTerm30.addEventListener('change', radioTermChange)
 radioTerm15.addEventListener('change', radioTermChange)
+additionalPrincipalField.addEventListener('change', addtlPrincChange)
 buttonCalc.addEventListener('click', calculateMortgage)
+
+function addtlPrincChange() {
+    myMortgage.additionalPrincipal = parseFloat(additionalPrincipalField.value);
+}
 
 function radioTermChange() {
     if (radioTerm30.checked) {
@@ -239,6 +245,7 @@ function populateMortgageDetail() {
             <td>${formatDollarsAndCents(amortSchedJSON[payment].principalInterest)}</td>
             <td>${formatDollarsAndCents(amortSchedJSON[payment].principal)}</td>
             <td>${formatDollarsAndCents(amortSchedJSON[payment].interest)}</td>
+            <td>${formatDollarsAndCents(amortSchedJSON[payment].additionalPrincipal)}</td>
             <td>${formatDollarsAndCents(amortSchedJSON[payment].principalOutstanding)}</td>
             <td>${formatDollarsAndCents(amortSchedJSON[payment].interestRunningTotal)}</td>
         </tr>`;


### PR DESCRIPTION
Taking the previous work to add the property of additional principal to the Mortgage object and making sure that it is calculating the updated amortization based on the amount specified by the end user after clicking the calculate button.